### PR TITLE
Remove ambiguous unary operator

### DIFF
--- a/src/SprykerShop/Yves/ProductOptionWidget/Theme/default/components/molecules/shopping-list-product-option-list/shopping-list-product-option-list.scss
+++ b/src/SprykerShop/Yves/ProductOptionWidget/Theme/default/components/molecules/shopping-list-product-option-list/shopping-list-product-option-list.scss
@@ -2,7 +2,7 @@ $shopping-list-product-option-list-padding: map-get($setting-spacing, 'small');
 
 @mixin product-option-widget-shopping-list-product-option-list($name: '.shopping-list-product-option-list') {
     #{$name} {
-        margin: 0 -$shopping-list-product-option-list-padding;
+        margin: 0 - $shopping-list-product-option-list-padding;
 
         &__item {
             padding: 0 $shopping-list-product-option-list-padding map-get($setting-spacing, 'default');


### PR DESCRIPTION
Since Dart-Sass Release Version 1.55.0 there is an Strict Unary Operator Warning for ambiguous use

https://github.com/sass/dart-sass/releases/tag/1.55.0
https://sass-lang.com/documentation/breaking-changes/strict-unary

Add a space after - to clarify that it's meant to be a binary operation, or wrap it in parentheses to make it a unary operation. This will be an error in future versions of Sass.